### PR TITLE
Redirection on "create new animal" cancel action solving issue #91

### DIFF
--- a/src/components/animal/create/DetailsStep.tsx
+++ b/src/components/animal/create/DetailsStep.tsx
@@ -34,7 +34,7 @@ function DetailsStep({ onNext }: DetailsStepProps) {
     }, [specie, setValue]);
 
     const handleCancel = () => {
-        history.push('/');
+        history.push('/animal-list');
     };
 
     return (


### PR DESCRIPTION
User is now redirected to Animal list page after clicking on Cancel button in Create new animal page. Solves issue #91.