### PR TITLE
Update integrate action: run on PRs from forks

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -1,6 +1,6 @@
 name: 'integrate'
 on:
-    push:
+    pull_request:
         branches-ignore:
             - main
 


### PR DESCRIPTION
The problem is "push" event is not triggered as PR comes from forks. These PRs are blocked and cannot be merged further on.
After the change, older PRs might not get this "integrate" action re-run.